### PR TITLE
Install Airbridge SDK and Migrate from Firebase Dynamic Links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,4 +87,6 @@ dependencies {
     implementation(project(":feature:detail"))
     implementation(project(":feature:recipe"))
     implementation(project(":feature:collection"))
+
+    implementation("io.airbridge:sdk-android:4.1.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- firebase dynamic links -->
+            <!-- Airbridge deeplinks -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="duckee.abr.ge"
+                    android:scheme="https" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -46,8 +56,16 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="duckee.page.link"
+                    android:host="duckee.airbridge.io"
                     android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="duckee" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/kotlin/xyz/duckee/android/DuckeeApplication.kt
+++ b/app/src/main/kotlin/xyz/duckee/android/DuckeeApplication.kt
@@ -19,9 +19,23 @@ import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import dagger.hilt.android.HiltAndroidApp
+import co.ab180.airbridge.Airbridge
+import co.ab180.airbridge.AirbridgeOption
+import co.ab180.airbridge.AirbridgeOptionBuilder
 
 @HiltAndroidApp
 class DuckeeApplication : Application(), ImageLoaderFactory {
+
+    override fun onCreate() {
+        super.onCreate()
+        initializeAirbridge()
+    }
+
+    private fun initializeAirbridge() {
+        val option = AirbridgeOptionBuilder("duckee", "fc57a50c7b39453fb2582e4991e326a7")
+            .build()
+        Airbridge.initializeSDK(this, option)
+    }
 
     override fun newImageLoader(): ImageLoader =
         ImageLoader.Builder(this)

--- a/app/src/main/kotlin/xyz/duckee/android/MainActivity.kt
+++ b/app/src/main/kotlin/xyz/duckee/android/MainActivity.kt
@@ -17,7 +17,6 @@ package xyz.duckee.android
 
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -25,9 +24,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.view.WindowCompat
 import androidx.navigation.NavHostController
-import com.google.firebase.dynamiclinks.PendingDynamicLinkData
-import com.google.firebase.dynamiclinks.ktx.dynamicLinks
-import com.google.firebase.ktx.Firebase
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,6 +44,7 @@ import xyz.duckee.android.core.navigation.navigateToDetailScreen
 import xyz.duckee.android.core.navigation.navigateToExploreTab
 import xyz.duckee.android.core.navigation.navigateToRecipeScreen
 import xyz.duckee.android.core.navigation.navigateToSignInScreen
+import co.ab180.airbridge.Airbridge
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -118,51 +115,55 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        handleAirbridgeDeeplink()
+    }
 
-        Firebase.dynamicLinks
-            .getDynamicLink(intent)
-            .addOnSuccessListener(this) { pendingDynamicLinkData: PendingDynamicLinkData? ->
-                pendingDynamicLinkData?.link?.let { deepLink ->
-                    val path = deepLink.path ?: return@let
-                    when {
-                        path.startsWith("/recipe/") -> {
-                            val recipePattern = "/recipe/(\\d+)".toRegex()
-                            val matchResult = recipePattern.find(path)
-                            matchResult?.let { result ->
-                                val recipeId = result.groupValues[1]
-                                navigationController?.navigateToRecipeScreen(recipeId)
-                            }
-                        }
+    private fun handleAirbridgeDeeplink() {
+        Airbridge.handleDeeplink(intent) { deeplink ->
+            handleDeeplink(deeplink)
+        }
 
-                        path.startsWith("/detail/") -> {
-                            val detailPattern = "/detail/([\\w-]+)".toRegex()
-                            val matchResult = detailPattern.find(path)
-                            matchResult?.let { result ->
-                                val detailId = result.groupValues[1]
-                                navigationController?.navigateToDetailScreen(detailId)
-                            }
-                        }
+        Airbridge.handleDeferredDeeplink { deeplink ->
+            deeplink?.let { handleDeeplink(it) }
+        }
+    }
 
-                        path == "/explore" -> {
-                            navigationController?.navigateToExploreTab()
-                        }
-
-                        path == "/collection" -> {
-                            navigationController?.navigateToCollectionTab()
-                        }
-
-                        path == "/signin" -> {
-                            navigationController?.navigateToSignInScreen()
-                        }
-
-                        else -> {
-                            Timber.tag("[DuckeeMainActivity]").w("Unhandled deep link path: $path")
-                        }
-                    }
+    private fun handleDeeplink(deeplink: Uri) {
+        val path = deeplink.path ?: return
+        when {
+            path.startsWith("/recipe/") -> {
+                val recipePattern = "/recipe/(\\d+)".toRegex()
+                val matchResult = recipePattern.find(path)
+                matchResult?.let { result ->
+                    val recipeId = result.groupValues[1]
+                    navigationController?.navigateToRecipeScreen(recipeId)
                 }
             }
-            .addOnFailureListener(this) { e ->
-                Timber.tag("[DuckeeMainActivity]").w(e, "getDynamicLink:onFailure")
+
+            path.startsWith("/detail/") -> {
+                val detailPattern = "/detail/([\\w-]+)".toRegex()
+                val matchResult = detailPattern.find(path)
+                matchResult?.let { result ->
+                    val detailId = result.groupValues[1]
+                    navigationController?.navigateToDetailScreen(detailId)
+                }
             }
+
+            path == "/explore" -> {
+                navigationController?.navigateToExploreTab()
+            }
+
+            path == "/collection" -> {
+                navigationController?.navigateToCollectionTab()
+            }
+
+            path == "/signin" -> {
+                navigationController?.navigateToSignInScreen()
+            }
+
+            else -> {
+                Timber.tag("[DuckeeMainActivity]").w("Unhandled deep link path: $path")
+            }
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
@@ -30,7 +30,8 @@ class AndroidFirebaseConventionPlugin : Plugin<Project> {
                 "implementation"(platform(libs.findLibrary("firebase.bom").get()))
                 "implementation"(libs.findLibrary("firebase.auth").get())
                 "implementation"(libs.findLibrary("firebase.authUI").get())
-                "implementation"(libs.findLibrary("firebase.dynamicLink").get())
+                // Remove the following line
+                // "implementation"(libs.findLibrary("firebase.dynamicLink").get())
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven { url = uri("https://sdk-download.airbridge.io/maven") }
     }
 }
 dependencyResolutionManagement {
@@ -15,6 +16,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
+        maven { url = uri("https://sdk-download.airbridge.io/maven") }
     }
 }
 


### PR DESCRIPTION
# Install Airbridge SDK and Migrate from Firebase Dynamic Links

This PR installs the Airbridge SDK and migrates the app from using Firebase Dynamic Links to Airbridge Deeplinks.

## Changes

- Added Airbridge SDK dependency
- Initialized Airbridge SDK in `DuckeeApplication`
- Removed Firebase Dynamic Links related code and dependencies
- Implemented Airbridge Deeplinks handling in `MainActivity`
- Updated `AndroidManifest.xml` to support Airbridge Deeplinks
- Updated Deeplink format

## Important Notes

- The Deeplink format has changed from Firebase Dynamic Links to Airbridge Deeplinks:
  - Old format: `https://duckee.page.link/...`
  - New format: `duckee://...`
- Examples of new Deeplink formats:
  - Recipe: `duckee://recipe/123`
  - Detail: `duckee://detail/abc-def-ghi`
  - Explore: `duckee://explore`
  - Collection: `duckee://collection`
  - Sign In: `duckee://signin`

## Action Required

- Update all existing Deeplinks in marketing materials and documentation to reflect the new format.
- Test the app thoroughly to ensure all Deeplink functionalities are working as expected with the new Airbridge implementation.

## Testing

Please test the following scenarios:

1. App installation and initialization
2. Deeplink handling for all supported paths
3. Deferred Deeplink handling
4. General app functionality to ensure no regressions

If you encounter any issues or have any questions, please don't hesitate to comment on this PR.