### PR TITLE
feat: Integrate Airbridge SDK and migrate from Firebase Dynamic Links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(libs.androidx.startup)
     implementation(libs.timber)
     implementation(libs.stripe)
+    implementation(libs.airbridge)
 
     implementation(project(":core:designsystem"))
     implementation(project(":core:navigation"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,20 +34,19 @@
             android:theme="@style/Theme.Duckee">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
-            <!-- firebase dynamic links -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="duckee.page.link"
-                    android:scheme="https" />
+                <data android:scheme="duckee" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:host="duckee.airbridge.io" android:scheme="https" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/kotlin/xyz/duckee/android/DeeplinkHandler.kt
+++ b/app/src/main/kotlin/xyz/duckee/android/DeeplinkHandler.kt
@@ -1,0 +1,67 @@
+package xyz.duckee.android
+
+import android.content.Intent
+import android.net.Uri
+import androidx.navigation.NavController
+import co.ab180.airbridge.Airbridge
+import timber.Timber
+import xyz.duckee.android.core.navigation.navigateToCollectionTab
+import xyz.duckee.android.core.navigation.navigateToDetailScreen
+import xyz.duckee.android.core.navigation.navigateToExploreTab
+import xyz.duckee.android.core.navigation.navigateToRecipeScreen
+import xyz.duckee.android.core.navigation.navigateToSignInScreen
+
+class DeeplinkHandler(private val navController: NavController?) {
+
+    fun handleDeeplink(intent: Intent) {
+        Airbridge.handleDeeplink(intent) { uri ->
+            handleDeeplinkUri(uri)
+        }
+    }
+
+    fun handleDeferredDeeplink() {
+        Airbridge.handleDeferredDeeplink { uri ->
+            uri?.let { handleDeeplinkUri(it) }
+        }
+    }
+
+    private fun handleDeeplinkUri(uri: Uri) {
+        val path = uri.path ?: return
+
+        when {
+            path.startsWith("/recipe/") -> {
+                val recipePattern = "/recipe/(\\d+)".toRegex()
+                val matchResult = recipePattern.find(path)
+                matchResult?.let { result ->
+                    val recipeId = result.groupValues[1]
+                    navController?.navigateToRecipeScreen(recipeId)
+                }
+            }
+
+            path.startsWith("/detail/") -> {
+                val detailPattern = "/detail/([\\w-]+)".toRegex()
+                val matchResult = detailPattern.find(path)
+                matchResult?.let { result ->
+                    val detailId = result.groupValues[1]
+                    navController?.navigateToDetailScreen(detailId)
+                }
+            }
+
+            path == "/explore" -> {
+                navController?.navigateToExploreTab()
+            }
+
+            path == "/collection" -> {
+                navController?.navigateToCollectionTab()
+            }
+
+            path == "/signin" -> {
+                navController?.navigateToSignInScreen()
+            }
+
+            else -> {
+                Timber.tag("[DeeplinkHandler]").w("Unhandled deep link path: $path")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/xyz/duckee/android/DuckeeApplication.kt
+++ b/app/src/main/kotlin/xyz/duckee/android/DuckeeApplication.kt
@@ -19,9 +19,21 @@ import android.app.Application
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import dagger.hilt.android.HiltAndroidApp
+import co.ab180.airbridge.Airbridge
+import co.ab180.airbridge.AirbridgeOption
+import co.ab180.airbridge.AirbridgeOptionBuilder
 
 @HiltAndroidApp
 class DuckeeApplication : Application(), ImageLoaderFactory {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val option = AirbridgeOptionBuilder("duckee", "46ea3b8f7e37448281f5c48b5def1a03")
+            .setTrackAirbridgeDeeplinkOnlyEnabled(true)
+            .build()
+        Airbridge.initializeSDK(this, option)
+    }
 
     override fun newImageLoader(): ImageLoader =
         ImageLoader.Builder(this)

--- a/build-logic/convention/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
@@ -30,7 +30,6 @@ class AndroidFirebaseConventionPlugin : Plugin<Project> {
                 "implementation"(platform(libs.findLibrary("firebase.bom").get()))
                 "implementation"(libs.findLibrary("firebase.auth").get())
                 "implementation"(libs.findLibrary("firebase.authUI").get())
-                "implementation"(libs.findLibrary("firebase.dynamicLink").get())
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,9 @@ protobufPlugin = "0.9.1"
 # DataStore
 datastore = "1.0.0"
 
+# Airbridge
+airbridge = "4.1.0"
+
 [libraries]
 
 # Build tools / Languages
@@ -130,6 +133,9 @@ protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", ve
 
 # Stripe Payment
 stripe = "com.stripe:stripe-android:20.19.2"
+
+# Airbridge
+airbridge = { module = "io.airbridge:sdk-android", version.ref = "airbridge" }
 
 [bundles]
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
+        maven { url = uri("https://sdk-download.airbridge.io/maven") }
     }
 }
 


### PR DESCRIPTION
# Airbridge SDK Integration

This PR integrates Airbridge SDK and migrates deeplink handling from Firebase Dynamic Links to Airbridge Deeplinks.

## Changes

- Added Airbridge SDK dependency and repository
- Initialized Airbridge SDK in DuckeeApplication
- Created DeeplinkHandler class for handling Airbridge deeplinks
- Updated MainActivity to use DeeplinkHandler
- Removed Firebase Dynamic Links dependency
- Updated AndroidManifest.xml with Airbridge intent filters

## Deeplink Format Changes

The deeplink format has changed from Firebase to Airbridge:

- Old: `https://duckee.page.link/xxxx`
- New: 
  - Scheme URL: `duckee://path`
  - Web URL: `https://duckee.airbridge.io/path`

### Supported Deeplink Paths

- `/recipe/{id}` - Opens recipe screen
- `/detail/{id}` - Opens detail screen
- `/explore` - Opens explore tab
- `/collection` - Opens collection tab
- `/signin` - Opens sign in screen

## Testing Instructions

1. Build and run the app
2. Test both scheme URLs and web URLs:
   - `duckee://recipe/123`
   - `https://duckee.airbridge.io/recipe/123`

## Note

Please update all marketing materials and documentation to use the new Airbridge deeplink format.